### PR TITLE
prvEMACHandlerTask: fix NetworkDown event

### DIFF
--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -884,10 +884,7 @@ static portTASK_FUNCTION( prvEMACHandlerTask, pvParameters )
 
         if( xPhyCheckLinkStatus( &xPhyObject, xResult ) != pdFALSE )
         {
-            if( pxEthHandle->gState != HAL_ETH_STATE_BUSY )
-            {
-                prvEthernetUpdateConfig( pxEthHandle );
-            }
+            prvEthernetUpdateConfig( pxEthHandle );
         }
     }
 }
@@ -960,8 +957,13 @@ static void prvEthernetUpdateConfig( ETH_HandleTypeDef * pxEthHandle )
     BaseType_t xResult;
     HAL_StatusTypeDef xHalResult;
 
-    if( prvGetPhyLinkStatus( pxMyInterface ) != pdFAIL )
+    if( prvGetPhyLinkStatus( pxMyInterface ) != pdFALSE )
     {
+        if(HAL_ETH_GetState(pxEthHandle) == HAL_ETH_STATE_STARTED) {
+            xHalResult = HAL_ETH_Stop_IT(pxEthHandle);
+            configASSERT(xHalResult == HAL_OK);
+        }
+
         #if ( niEMAC_AUTO_NEGOTIATION != 0 )
             /* TODO: xPhyStartAutoNegotiation always returns 0, Should return -1 if xPhyGetMask == 0 ? */
             xResult = xPhyStartAutoNegotiation( &xPhyObject, xPhyGetMask( &xPhyObject ) );


### PR DESCRIPTION
Description
-----------

For some reason `pxEthHandle->gState` I always have BUSY, which blocks the `prvEthernetUpdateConfig()` call.

As a result, `NetworkDown` is never issued when the cable is disconnected and `NetworkUp` is never issued when the cable is connected again (because it is already in `UP` state), causing DHCP to fail on the second cable connection.

Removing the HAL busy check works fine, no problems detected.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
