### PR TITLE
Fix priority set

### DIFF
--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -1038,12 +1038,11 @@ static BaseType_t prvEthConfigInit( ETH_HandleTypeDef * pxEthHandle, const Netwo
             }
         #endif
 
-        uint32_t ulPreemptPriority, ulSubPriority;
-        HAL_NVIC_GetPriority( ETH_IRQn, HAL_NVIC_GetPriorityGrouping(), &ulPreemptPriority, &ulSubPriority );
-        if( ulPreemptPriority < configMAX_FREERTOS_INTERRUPT_PRIORITY )
+        uint32_t ulPriority = NVIC_GetPriority( ETH_IRQn ) << ( 8 - configPRIO_BITS );
+        if( ulPriority < configMAX_SYSCALL_INTERRUPT_PRIORITY )
         {
             FreeRTOS_debug_printf( ( "prvEthConfigInit: Incorrectly set ETH_IRQn priority\n" ) );
-            HAL_NVIC_SetPriority( ETH_IRQn, ( uint32_t ) configMAX_FREERTOS_INTERRUPT_PRIORITY, 0 );
+            NVIC_SetPriority( ETH_IRQn, configMAX_SYSCALL_INTERRUPT_PRIORITY >> ( 8 - configPRIO_BITS ) );
         }
         if( NVIC_GetEnableIRQ( ETH_IRQn ) == 0 )
         {


### PR DESCRIPTION
Usually Cortex-M ports are using something similar to

```c
#define configPRIO_BITS       		__NVIC_PRIO_BITS
#define configMAX_SYSCALL_INTERRUPT_PRIORITY 	( <some_number> << (8 - configPRIO_BITS) )
```
https://github.com/FreeRTOS/FreeRTOS/blob/154dee1c86195d88c49ba5c58c8725c16541cc16/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/FreeRTOSConfig.h#L124 

So, fixed the code to compatible with `configMAX_SYSCALL_INTERRUPT_PRIORITY` and set priority like it was implemented in ATSAME5x port ( https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/f01dd0527be9b8b3de83adea08e442936a055773/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c#L570 )

