### PR TITLE
remove xCheckLoopback() usage

### DIFF
--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -590,16 +590,6 @@ static BaseType_t prvNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
             break;
         }
 
-        if( xCheckLoopback( pxDescriptor, xReleaseAfterSend ) != pdFALSE )
-        {
-            /* The packet has been sent back to the IP-task.
-             * The IP-task will further handle it.
-             * Do not release the descriptor. */
-            xReleaseAfterSend = pdFALSE;
-            FreeRTOS_debug_printf( ( "xNetworkInterfaceOutput: Loopback\n" ) );
-            break;
-        }
-
         if( prvGetPhyLinkStatus( pxInterface ) == pdFALSE )
         {
             FreeRTOS_debug_printf( ( "xNetworkInterfaceOutput: Link Down\n" ) );


### PR DESCRIPTION
Fixes compilation after https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/commit/7a58ae819ce3ca3f79a4e167d4a193da54ba2205