### PR TITLE
Increment MAC entry index

### DIFF
--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -1570,7 +1570,7 @@ static BaseType_t prvSetNewDestMACAddrMatch( ETH_TypeDef * const pxEthInstance,
         if( ucAddrHashCounters[ ucHashIndex ] == 0U )
         {
             prvHAL_ETH_SetDestMACAddrMatch( pxEthInstance, uxMACEntryIndex, pucMACAddr );
-            ucSrcMatchCounters[ uxMACEntryIndex ] = 1U;
+            ucSrcMatchCounters[ uxMACEntryIndex++ ] = 1U;
             xResult = pdTRUE;
         }
     }


### PR DESCRIPTION
I noticed the MAC entry index was never incremented, resulting in newer MAC addresses overriding the previous ones.